### PR TITLE
Implement joystick calibration from device

### DIFF
--- a/prog4/consoleiface/input.go
+++ b/prog4/consoleiface/input.go
@@ -123,27 +123,26 @@ func selectJoyCon(m *Manager, argv []string) (jc jcpc.JoyCon, newArgv []string, 
 	}
 }
 
-const batteryBarGraph = ""
 const colorBad = "\033[1m\033[41m\033[37m"
 const colorMid = "\033[1m\033[33m"
 const colorGood = "\033[1m\033[32m"
 const colorReset = "\033[m"
+const textCharging = " ⚡ "
 
 var batteryStatus = []string{
-	"🔋 " + "❓" + " ",
+	"🔋 " + colorBad + "！" + colorReset,
 	"🔋 " + colorBad + "▁ " + colorReset,
-	"🔋 " + colorBad + "▂ " + colorReset,
-	"🔋 " + colorBad + "▃ " + colorReset,
-	"🔋 " + colorMid + "▄ " + colorReset,
+	"🔋 " + colorMid + "▃ " + colorReset,
 	"🔋 " + colorMid + "▅ " + colorReset,
-	"🔋 " + colorMid + "▆ " + colorReset,
-	"🔋 " + colorMid + "▇ " + colorReset,
 	"🔋 " + colorGood + "█ " + colorReset,
-	"🔋 " + "⚡ ",
 }
 
-func renderBattery(l int8) string {
-	return batteryStatus[l]
+func renderBattery(level int8, charging bool) string {
+	if charging {
+		return batteryStatus[level] + textCharging
+	} else {
+		return batteryStatus[level]
+	}
 }
 
 func printConnectedJoyCons(m *Manager) {

--- a/prog4/controller/one.go
+++ b/prog4/controller/one.go
@@ -59,7 +59,7 @@ func (c *one) update() {
 	if c.stdTransitionDelay > 0 {
 		c.stdTransitionDelay--
 		if c.stdTransitionDelay == 0 {
-			c.jc.ChangeInputMode(jcpc.ModeStandard)
+			c.jc.ChangeInputMode(jcpc.InputStandard)
 		}
 	}
 }

--- a/prog4/controller/two.go
+++ b/prog4/controller/two.go
@@ -87,8 +87,8 @@ func (c *two) updateBoth() {
 	if c.stdTransitionDelay > 0 {
 		c.stdTransitionDelay--
 		if c.stdTransitionDelay == 0 {
-			c.left.ChangeInputMode(jcpc.ModeStandard)
-			c.right.ChangeInputMode(jcpc.ModeStandard)
+			c.left.ChangeInputMode(jcpc.InputStandard)
+			c.right.ChangeInputMode(jcpc.InputStandard)
 		}
 	}
 }

--- a/prog4/joycon/bluetooth.go
+++ b/prog4/joycon/bluetooth.go
@@ -3,6 +3,7 @@ package joycon
 import (
 	"context"
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"image/color"
 	"sync"
@@ -30,12 +31,13 @@ type joyconBluetooth struct {
 	controller jcpc.Controller
 	ui         jcpc.Interface
 
-	battery   int8
+	packet1   uint8
 	buttons   jcpc.ButtonState
-	raw_stick [2][2]byte
-	calib     [2]*calibrationData
+	raw_stick [2][2]uint16       // left, right; x, y
+	calib     [2]calibrationData // left, right
 	haveGyro  bool
 	gyro      [3]jcpc.GyroFrame
+	// TODO gyro calibration
 
 	haveColors  bool
 	caseColor   color.RGBA
@@ -61,17 +63,19 @@ func NewBluetooth(hidHandle *hid.Device, side jcpc.JoyConType, ui jcpc.Interface
 		return nil, err
 	}
 	jc.side = side
-	if side == jcpc.TypeLeft {
-		jc.calib[0] = cachedCalibration(jc.serial)
-	} else if side == jcpc.TypeRight {
-		jc.calib[1] = cachedCalibration(jc.serial)
-	}
 	jc.controller = nil
 	jc.haveColors = false
-	jc.mode = jcpc.ModeLazyButtons
+	jc.mode = jcpc.InputLazyButtons
 	jc.isAlive = true
 
 	go jc.reader()
+
+	// Read stick calibration and case colors
+	// TODO cache this data
+	go func() {
+		_, _ = jc.SPIRead(factoryStickCalibStart, factoryStickCalibLen)
+		_, _ = jc.SPIRead(userStickCalibStart, userStickCalibLen)
+	}()
 	return jc, nil
 }
 
@@ -87,8 +91,11 @@ func (jc *joyconBluetooth) Buttons() jcpc.ButtonState {
 	return jc.buttons
 }
 
-func (jc *joyconBluetooth) Battery() int8 {
-	return jc.battery
+// Battery level and charging state.
+//
+// 4=full, 3, 2, 1=critical, 0=empty. true=charging.
+func (jc *joyconBluetooth) Battery() (int8, bool) {
+	return int8(jc.packet1 >> 5), jc.packet1 & 0x10 != 0
 }
 
 func (jc *joyconBluetooth) CaseColor() color.RGBA {
@@ -96,7 +103,7 @@ func (jc *joyconBluetooth) CaseColor() color.RGBA {
 }
 
 func (jc *joyconBluetooth) ButtonColor() color.RGBA {
-	return jc.caseColor
+	return jc.buttonColor
 }
 
 func (jc *joyconBluetooth) EnableGyro(status bool) {
@@ -111,12 +118,8 @@ func (jc *joyconBluetooth) EnableGyro(status bool) {
 	jc.mu.Unlock()
 }
 
-func (jc *joyconBluetooth) RawSticks(axis jcpc.AxisID) [2]byte {
-	if axis == jcpc.Axis_L_Horiz || axis == jcpc.Axis_L_Vertical {
-		return jc.raw_stick[0]
-	} else {
-		return jc.raw_stick[1]
-	}
+func (jc *joyconBluetooth) RawSticks() [2][2]uint16 {
+	return jc.raw_stick
 }
 
 func (jc *joyconBluetooth) ChangeInputMode(newMode jcpc.InputMode) bool {
@@ -124,26 +127,14 @@ func (jc *joyconBluetooth) ChangeInputMode(newMode jcpc.InputMode) bool {
 	defer jc.mu.Unlock()
 
 	if newMode == jc.mode {
-		return true
+		return false
 	}
 
-	if !newMode.NeedsMode3() {
-		if jc.mode.NeedsMode3() {
-			// TODO - soft disconnect? e.g. on controller reset
-			return false
-		} else {
-			jc.mode = newMode
-			return true
-		}
-	} else {
-		cmd := []byte{0x03, 0x30}
-		if newMode == jcpc.ModeNFC {
-			cmd[1] = 0x31
-		}
-		jc.subcommandQueue = append(jc.subcommandQueue, cmd)
-		//jc.mode = newMode
-		return true
-	}
+	cmd := []byte{0x03, byte(newMode)}
+	jc.subcommandQueue = append(jc.subcommandQueue, cmd)
+	jc.mode = newMode
+
+	return true
 }
 
 func (jc *joyconBluetooth) ReadInto(out *jcpc.CombinedState, includeGyro bool) {
@@ -151,7 +142,6 @@ func (jc *joyconBluetooth) ReadInto(out *jcpc.CombinedState, includeGyro bool) {
 	defer jc.mu.Unlock()
 
 	out.Buttons = out.Buttons.Union(jc.buttons)
-	// TODO send CALIBRATED stick data
 	if jc.side.IsLeft() {
 		out.AdjSticks[0] = jc.calib[0].Adjust(jc.raw_stick[0])
 	}
@@ -160,7 +150,7 @@ func (jc *joyconBluetooth) ReadInto(out *jcpc.CombinedState, includeGyro bool) {
 	}
 
 	if includeGyro && jc.haveGyro {
-		out.Gyro = jc.gyro
+		out.Gyro = jc.gyro // TODO 6axis calibration
 	}
 }
 
@@ -175,6 +165,7 @@ func (jc *joyconBluetooth) Rumble(d []jcpc.RumbleData) {
 	jc.rumbleQueue = append(jc.rumbleQueue, d...)
 }
 
+// Perform a SPI read and block for the result.
 func (jc *joyconBluetooth) SPIRead(addr uint32, len byte) ([]byte, error) {
 	cmd := []byte{0x10, 0, 0, 0, 0, len}
 	ch := make(chan []byte)
@@ -410,7 +401,7 @@ func (jc *joyconBluetooth) onReadError(err error) {
 	jc.hidHandle = nil
 	jc.mu.Unlock()
 
-	fmt.Printf("[ ERR] JoyCon %p read error: %v\n", jc, err)
+	fmt.Printf("[ ERR] JoyCon %s read error: %v\n", jc.serial, err)
 
 	go notify(jc, jcpc.NotifyConnection, jc.ui, jc.controller)
 }
@@ -421,24 +412,20 @@ func (jc *joyconBluetooth) fillInput(packet []byte) {
 	packet = packet[1:]
 
 	// timer := packet[0]
-	newBattery := int8((packet[1] & 0xF0) >> 4)
-	batteryChanged := jc.battery != newBattery
-	jc.battery = newBattery
-	if batteryChanged {
+	prevBattery := jc.packet1 & 0xF0
+	jc.packet1 = packet[1]
+	if prevBattery != (packet[1] & 0xF0) {
 		go jc.ui.JoyConUpdate(jc, jcpc.NotifyBattery)
 	}
 
 	jc.buttons = jcpc.ButtonsFromSlice(packet[2:5])
 
 	if jc.side.IsLeft() {
-		jc.raw_stick[0][0] = ((packet[6] & 0x0F) << 4) | ((packet[5] & 0xF0) >> 4)
-		jc.raw_stick[0][1] = packet[7]
+		jc.raw_stick[0][0], jc.raw_stick[0][1] = decodeUint12(packet[5:8])
 	}
 	if jc.side.IsRight() {
-		jc.raw_stick[1][0] = ((packet[9] & 0x0F) << 4) | ((packet[8] & 0xF0) >> 4)
-		jc.raw_stick[1][1] = packet[10]
+		jc.raw_stick[1][0], jc.raw_stick[1][1] = decodeUint12(packet[8:11])
 	}
-	// ?? packet[11]
 
 	jc.mu.Unlock()
 }
@@ -473,7 +460,7 @@ func (jc *joyconBluetooth) fillGyroData(packet []byte) {
 		}
 	}
 
-	fmt.Printf("Gyro data:\n")
+	fmt.Print("Gyro data:\n")
 	gyroPrint(gyroDiff(prevFrame, jc.gyro[0]))
 	gyroPrint(jc.gyro[0])
 	gyroPrint(gyroDiff(jc.gyro[0], jc.gyro[1]))
@@ -497,23 +484,41 @@ func (jc *joyconBluetooth) handleSubcommandReply(_packet []byte) {
 		return
 	}
 
-	//fmt.Println("got subcommand reply packet:", replyPacketID, packet[12:])
+	unknown := false
 	switch replyPacketID {
+	case 0x01: // Manual Pairing
+		unknown = true
+	case 0x02: // Device Info
+		fmt.Printf("%s: Firmware %d.%d, type %d, MAC %02X:%02X:%02X:%02X:%02X:%02X, colors_on %d\n",
+			jc.serial, int(packet[0]), int(packet[1]),
+			packet[2], /* packet[3], */
+			packet[4], packet[5], packet[6], packet[7], packet[8], packet[9],
+			/* packet[10], */
+			packet[11],
+		)
+	case 0x03: // Set Input Report Mode
+		unknown = true
+	case 0x04: // Shoulder buttons time elapsed
+		unknown = true
 	case 0x10: // SPI Flash Read
 		jc.handleSPIRead(packet[12:])
-	case 0x03:
-		fallthrough
-	case 0x40:
-		fallthrough
-	case 0x50:
-		fallthrough
+	case 0x43: // IMU Register Read
+		unknown = true
+	case 0x50: // Get Voltage
+		unknown = true
+	case 0x52: // Get unknown data
+		unknown = true
 	default:
-		fmt.Println("got subcommand reply packet:", replyPacketID, packet[12:])
+		unknown = true
+	}
+
+	if unknown {
+		fmt.Printf("got subcommand reply packet: %d\n%s", replyPacketID, hex.Dump(packet[12:]))
 	}
 }
 
 func (jc *joyconBluetooth) handleButtonPush(packet []byte) {
-	if jc.mode != jcpc.ModeLazyButtons {
+	if jc.mode != jcpc.InputLazyButtons {
 		return
 	}
 
@@ -551,25 +556,16 @@ func (jc *joyconBluetooth) reader() {
 			continue
 		}
 
-		//fmt.Println(packet)
 		switch packet[0] {
 		case 0x21:
 			jc.fillInput(packet)
 			jc.handleSubcommandReply(packet)
 			notify(jc, jcpc.NotifyInput, jc.ui, jc.controller)
 		case 0x30:
-			jc.mu.Lock()
-			jc.mode = jcpc.ModeStandard
-			jc.mu.Unlock()
-
 			jc.fillInput(packet)
 			jc.fillGyroData(packet)
 			notify(jc, jcpc.NotifyInput, jc.ui, jc.controller)
 		case 0x31, 0x32, 0x33:
-			jc.mu.Lock()
-			jc.mode = jcpc.ModeNFC
-			jc.mu.Unlock()
-
 			jc.fillInput(packet)
 			jc.handleSubcommandReply(packet)
 			notify(jc, jcpc.NotifyInput, jc.ui, jc.controller)
@@ -577,10 +573,17 @@ func (jc *joyconBluetooth) reader() {
 			jc.handleButtonPush(packet)
 		default:
 			fmt.Println("[!!] Unknown INPUT packet type ", packet[0])
-			fmt.Printf("Packet %02X: %v\n", packet[0], packet)
+			fmt.Printf("Packet %02X:\n%s", packet[0], hex.Dump(packet[1:]))
 		}
 	}
 }
+
+const (
+	factoryStickCalibStart = 0x603D
+	factoryStickCalibLen = 25
+	userStickCalibStart = 0x8010
+	userStickCalibLen = 22
+)
 
 func (jc *joyconBluetooth) handleSPIRead(packet []byte) {
 	addr := binary.LittleEndian.Uint32(packet[2:])
@@ -591,22 +594,44 @@ func (jc *joyconBluetooth) handleSPIRead(packet []byte) {
 		data = packet[7 : 7+length]
 	}
 
-	if addr == 0x6050 && length == 6 {
+	if addr == factoryStickCalibStart && length == factoryStickCalibLen {
 		jc.mu.Lock()
-		jc.haveColors = true
-		jc.caseColor.R = data[0]
-		jc.caseColor.G = data[1]
-		jc.caseColor.B = data[2]
+		jc.calib[0].Parse(data[0:9])
+		jc.calib[1].Parse(data[9:18])
+		// one padding byte
+		const colorOffset = 19
+		jc.caseColor.R = data[colorOffset+0]
+		jc.caseColor.G = data[colorOffset+1]
+		jc.caseColor.B = data[colorOffset+2]
 		jc.caseColor.A = 255
-		jc.buttonColor.R = data[3]
-		jc.buttonColor.G = data[4]
-		jc.buttonColor.B = data[5]
+		jc.buttonColor.R = data[colorOffset+3]
+		jc.buttonColor.G = data[colorOffset+4]
+		jc.buttonColor.B = data[colorOffset+5]
 		jc.buttonColor.A = 255
 		jc.mu.Unlock()
-	} else if addr == 0x2024 && length == 0x1C {
-		// ParseCalibrationData
+
+		if true {
+			fmt.Printf("%s: Got factory calibration and button colors\n", jc.serial)
+		}
+	} else if addr == userStickCalibStart && length == userStickCalibLen {
+		had := false
 		jc.mu.Lock()
+		const magicHaveCalibration = 0xA1B2
+		if binary.LittleEndian.Uint16(data[0:2]) == magicHaveCalibration {
+			jc.calib[0].Parse(data[2:2+9])
+			had = true
+		}
+		if binary.LittleEndian.Uint16(data[11:13]) == magicHaveCalibration {
+			jc.calib[1].Parse(data[13:13+9])
+			had = true
+		}
 		jc.mu.Unlock()
+
+		if had {
+			fmt.Printf("%s: Read user stick calibration\n", jc.serial)
+		} else {
+			fmt.Printf("%s: Checked user stick calibration\n", jc.serial)
+		}
 	}
 
 	jc.mu.Lock()

--- a/prog4/joycon/common.go
+++ b/prog4/joycon/common.go
@@ -49,10 +49,17 @@ type calibrationData struct {
 	xMinOff, yMinOff uint16
 }
 
-func (c *calibrationData) Parse(b []byte) {
-	c.xMaxOff, c.yMaxOff = decodeUint12(b[0:3])
-	c.xCenter, c.yCenter = decodeUint12(b[3:6])
-	c.xMinOff, c.yMinOff = decodeUint12(b[6:9])
+// side must be TypeLeft or TypeRight; TypeBoth controllers should call this twice
+func (c *calibrationData) Parse(b []byte, side jcpc.JoyConType) {
+	if side == jcpc.TypeLeft {
+		c.xMaxOff, c.yMaxOff = decodeUint12(b[0:3])
+		c.xCenter, c.yCenter = decodeUint12(b[3:6])
+		c.xMinOff, c.yMinOff = decodeUint12(b[6:9])
+	} else {
+		c.xCenter, c.yCenter = decodeUint12(b[0:3])
+		c.xMinOff, c.yMinOff = decodeUint12(b[3:6])
+		c.xMaxOff, c.yMaxOff = decodeUint12(b[6:9])
+	}
 }
 
 const magnitudeMax = 1.0
@@ -74,7 +81,7 @@ func (_c *calibrationData) Adjust(rawStick [2]uint16) [2]int16 {
 	c := _c
 	if c == nil {
 		c = &fakeCalibrationData
-	} else if c.xCenter == 0 {
+	} else if c.xCenter == 4095 {
 		c = &fakeCalibrationData
 	}
 

--- a/prog4/output/console.go
+++ b/prog4/output/console.go
@@ -30,7 +30,7 @@ func (c *consoleOutput) ButtonUpdate(bu jcpc.ButtonID, state bool) {
 	fmt.Printf("[Controller %d] %s %s\n", c.i, bu.String(), pressed)
 }
 
-func (c *consoleOutput) StickUpdate(axis jcpc.AxisID, value int8) {
+func (c *consoleOutput) StickUpdate(axis jcpc.AxisID, value int16) {
 
 }
 

--- a/prog4/output/uinput_linux.go
+++ b/prog4/output/uinput_linux.go
@@ -126,10 +126,10 @@ func (o *uinput) setupNewKernel(m ControllerMapping, name string) error {
 		}
 	}
 	abs_setup.absinfo.value = 0
-	abs_setup.absinfo.min = -128
-	abs_setup.absinfo.max = 128
-	abs_setup.absinfo.fuzz = 2
-	abs_setup.absinfo.flat = 2
+	abs_setup.absinfo.min = -0x7FF
+	abs_setup.absinfo.max = 0x7FF
+	abs_setup.absinfo.fuzz = 4
+	abs_setup.absinfo.flat = 4
 	o.axes = m.Axes
 	for _, e := range o.axes {
 		if e.Name == "" {
@@ -172,10 +172,10 @@ func (o *uinput) setupOldKernel(m ControllerMapping, name string) error {
 		if code > maxAxis {
 			maxAxis = code
 		}
-		setup.absmin[code] = -128
-		setup.absmax[code] = 128
-		setup.absflat[code] = 2
-		setup.absfuzz[code] = 2
+		setup.absmin[code] = -0x7FF
+		setup.absmax[code] = 0x7FF
+		setup.absflat[code] = 4
+		setup.absfuzz[code] = 4
 	}
 
 	for code := uint16(0); code <= maxAxis; code++ {
@@ -303,6 +303,7 @@ func (o *uinput) setPermissions() error {
 			fmt.Println("set permissions for", m)
 		}
 	}
+
 	return nil
 }
 
@@ -327,7 +328,7 @@ func (o *uinput) ButtonUpdate(b jcpc.ButtonID, state bool) {
 	})
 }
 
-func (o *uinput) StickUpdate(axis jcpc.AxisID, value int8) {
+func (o *uinput) StickUpdate(axis jcpc.AxisID, value int16) {
 	var code uint16
 	var ok bool
 	var invert bool

--- a/vendor/github.com/GeertJohan/go.hid/hidraw_linux.go
+++ b/vendor/github.com/GeertJohan/go.hid/hidraw_linux.go
@@ -32,6 +32,12 @@ int get_ioctl_get_feature(int length) {
 	return HIDIOCGFEATURE(length);
 }
 
+int hidraw_get_bdaddr(int fd, char *buf, size_t maxlen) {
+	return ioctl(fd,
+		HIDIOCGRAWNAME(maxlen),
+		buf);
+}
+
 */
 import "C"
 


### PR DESCRIPTION

 - Fix battery to separate out levels from charging
 - Rename input modes
 - Add `decodeUint12` function
 - Change stick data to int16, change output range to (-0x7FF, +0x7FF)
 - Change stick calibration function

Fixes #15, #16
