### PR TITLE
Axis-remapping via cli-flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ which is then available to the rest of the system.
 
 If you want the joycons to function as a pair of controllers with analog sticks, press the SL + SR buttons to pair as a single controller.
 
+If your game needs a stick axis to be inverted, specify --invert LV (or LH, RV, RH) when running jcdriver.
+
 TODO: Interface to switch between the modes / drop controllers for re-pairing
 
 ## Limitations
@@ -50,7 +52,7 @@ If I neglect your contributions, try pinging me on Twitter (@riking27); I may ha
  - Linux: accept reconnect requests from the controllers
  - "Active scanning" mode to pick up new controllers without holding down SYNC button
  - Configuration storage - save calibration data so it doesn't need to be pulled on every connection
- - Button and **stick axis** remapping - some games want stick inverted
+ - Button remapping
  - Motion control support
     - Figure out how to work the insane system Linux has of delivering gyro data. Consider requiring use of a custom protocol.
  - Implement as a C++ library

--- a/prog4/consoleiface/Manager.go
+++ b/prog4/consoleiface/Manager.go
@@ -44,9 +44,11 @@ type Manager struct {
 
 	// flags to set for the main loop
 	doAttemptPairing bool
+
+	options jcpc.Options
 }
 
-func New(of jcpc.OutputFactory, bt jcpc.BluetoothManager) *Manager {
+func New(of jcpc.OutputFactory, bt jcpc.BluetoothManager, opts jcpc.Options) *Manager {
 	m := &Manager{
 		outputFactory: of,
 		btManager:     bt,
@@ -54,6 +56,7 @@ func New(of jcpc.OutputFactory, bt jcpc.BluetoothManager) *Manager {
 		commandChan:      make(chan string, 1),
 		attemptPairingCh: make(chan struct{}, 1),
 		consoleExit:      make(chan struct{}),
+		options: opts,
 	}
 
 	return m
@@ -168,7 +171,7 @@ func (m *Manager) doPairing_(idx1, idx2 int) {
 	if idx2 == -1 && m.unpaired[idx1].jc.Type() != jcpc.TypeBoth {
 		fmt.Println("pairing single")
 		jc := m.unpaired[idx1].jc
-		o, err := m.outputFactory(jc.Type(), pNum)
+		o, err := m.outputFactory(jc.Type(), pNum, m.options.InputRemapping)
 		if err != nil {
 			fmt.Println("[FATAL] Failed to create controller output:", err)
 			os.Exit(1)
@@ -185,7 +188,7 @@ func (m *Manager) doPairing_(idx1, idx2 int) {
 	} else if idx2 == -1 {
 		fmt.Println("pairing pro")
 		jc := m.unpaired[idx1].jc
-		o, err := m.outputFactory(jcpc.TypeBoth, pNum)
+		o, err := m.outputFactory(jcpc.TypeBoth, pNum, m.options.InputRemapping)
 		if err != nil {
 			fmt.Println("[FATAL] Failed to create controller output:", err)
 			os.Exit(1)
@@ -203,7 +206,7 @@ func (m *Manager) doPairing_(idx1, idx2 int) {
 		fmt.Println("pairing double")
 		jc1 := m.unpaired[idx1].jc
 		jc2 := m.unpaired[idx2].jc
-		o, err := m.outputFactory(jcpc.TypeBoth, pNum)
+		o, err := m.outputFactory(jcpc.TypeBoth, pNum, m.options.InputRemapping)
 		if err != nil {
 			fmt.Println("[FATAL] Failed to create controller output:", err)
 			os.Exit(1)

--- a/prog4/consoleiface/Manager.go
+++ b/prog4/consoleiface/Manager.go
@@ -56,7 +56,7 @@ func New(of jcpc.OutputFactory, bt jcpc.BluetoothManager, opts jcpc.Options) *Ma
 		commandChan:      make(chan string, 1),
 		attemptPairingCh: make(chan struct{}, 1),
 		consoleExit:      make(chan struct{}),
-		options: opts,
+		options:          opts,
 	}
 
 	return m

--- a/prog4/jcdriver/main.go
+++ b/prog4/jcdriver/main.go
@@ -7,9 +7,30 @@ import (
 	"time"
 
 	"github.com/riking/joycon/prog4/consoleiface"
+	"github.com/riking/joycon/prog4/jcpc"
+	"flag"
 )
 
+//this is needed so we can have one flag multiple times, like --invert LV --invert LH
+type arrayFlags []string
+
+func (i *arrayFlags) String() string {
+    return ""
+}
+
+func (i *arrayFlags) Set(value string) error {
+    *i = append(*i, value)
+    return nil
+}
+
+var invertedAxes arrayFlags
+
 func main() {
+	flag.Var(&invertedAxes,"invert","Stick-Axes to invert. --invert LV inverts the vertical axis of the left stick. Can be specified multiple times.")
+	flag.Parse()
+
+
+
 	// need 1 thread per blocked cgo call
 	runtime.GOMAXPROCS(8 + runtime.NumCPU())
 
@@ -21,11 +42,40 @@ func main() {
 		os.Exit(8)
 	}
 
-	iface := consoleiface.New(of, bt)
+	opts, err := OptionsFromFlags()
+	if err != nil{
+		fmt.Println("Error when parsing flags:",err.Error())
+		os.Exit(1)
+	}
+	iface := consoleiface.New(of, bt,*opts)
 	iface.Run()
 
 	defer func() {
 		fmt.Println("exiting...")
 		time.Sleep(2 * time.Second)
 	}()
+}
+
+// OptionsFormFlags parses the cli-flags into an Options-Struct
+func OptionsFromFlags()(*jcpc.Options,error){
+	opts := jcpc.Options{}
+
+
+	stringToAxis := map[string]jcpc.AxisID{
+		"LV": jcpc.Axis_L_Vertical,
+		"LH": jcpc.Axis_L_Horiz,
+		"RV": jcpc.Axis_R_Vertical,
+		"RH": jcpc.Axis_R_Horiz,
+	}
+
+	for _,v := range invertedAxes{
+		if axisid, exists := stringToAxis[v]; exists{
+			opts.InputRemapping.InvertedAxes = append(opts.InputRemapping.InvertedAxes,axisid)
+		}else{
+			return nil, fmt.Errorf("Unknown Axis %s. Please input only values like (L/R)(V/H)",v)
+		}
+	}
+
+
+	return &opts, nil
 }

--- a/prog4/jcdriver/main.go
+++ b/prog4/jcdriver/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"runtime"
@@ -8,28 +9,25 @@ import (
 
 	"github.com/riking/joycon/prog4/consoleiface"
 	"github.com/riking/joycon/prog4/jcpc"
-	"flag"
 )
 
 //this is needed so we can have one flag multiple times, like --invert LV --invert LH
 type arrayFlags []string
 
 func (i *arrayFlags) String() string {
-    return ""
+	return ""
 }
 
 func (i *arrayFlags) Set(value string) error {
-    *i = append(*i, value)
-    return nil
+	*i = append(*i, value)
+	return nil
 }
 
 var invertedAxes arrayFlags
 
 func main() {
-	flag.Var(&invertedAxes,"invert","Stick-Axes to invert. --invert LV inverts the vertical axis of the left stick. Can be specified multiple times.")
+	flag.Var(&invertedAxes, "invert", "Stick-Axes to invert. --invert LV inverts the vertical axis of the left stick. Can be specified multiple times.")
 	flag.Parse()
-
-
 
 	// need 1 thread per blocked cgo call
 	runtime.GOMAXPROCS(8 + runtime.NumCPU())
@@ -43,11 +41,11 @@ func main() {
 	}
 
 	opts, err := OptionsFromFlags()
-	if err != nil{
-		fmt.Println("Error when parsing flags:",err.Error())
+	if err != nil {
+		fmt.Println("Error when parsing flags:", err.Error())
 		os.Exit(1)
 	}
-	iface := consoleiface.New(of, bt,*opts)
+	iface := consoleiface.New(of, bt, *opts)
 	iface.Run()
 
 	defer func() {
@@ -57,9 +55,8 @@ func main() {
 }
 
 // OptionsFormFlags parses the cli-flags into an Options-Struct
-func OptionsFromFlags()(*jcpc.Options,error){
+func OptionsFromFlags() (*jcpc.Options, error) {
 	opts := jcpc.Options{}
-
 
 	stringToAxis := map[string]jcpc.AxisID{
 		"LV": jcpc.Axis_L_Vertical,
@@ -68,14 +65,13 @@ func OptionsFromFlags()(*jcpc.Options,error){
 		"RH": jcpc.Axis_R_Horiz,
 	}
 
-	for _,v := range invertedAxes{
-		if axisid, exists := stringToAxis[v]; exists{
-			opts.InputRemapping.InvertedAxes = append(opts.InputRemapping.InvertedAxes,axisid)
-		}else{
-			return nil, fmt.Errorf("Unknown Axis %s. Please input only values like (L/R)(V/H)",v)
+	for _, v := range invertedAxes {
+		if axisid, exists := stringToAxis[v]; exists {
+			opts.InputRemapping.InvertedAxes = append(opts.InputRemapping.InvertedAxes, axisid)
+		} else {
+			return nil, fmt.Errorf("Unknown Axis %s. Please input only values like (L/R)(V/H)", v)
 		}
 	}
-
 
 	return &opts, nil
 }

--- a/prog4/jcdriver/output_uinput.go
+++ b/prog4/jcdriver/output_uinput.go
@@ -10,14 +10,14 @@ import (
 )
 
 func getOutputFactory() jcpc.OutputFactory {
-	return func(t jcpc.JoyConType, playerNum int) (jcpc.Output, error) {
+	return func(t jcpc.JoyConType, playerNum int, remap jcpc.InputRemappingOptions) (jcpc.Output, error) {
 		switch t {
 		case jcpc.TypeLeft:
-			return output.NewUInput(output.MappingL, fmt.Sprintf("Half Joy-Con %d", playerNum))
+			return output.NewUInput(output.MappingL, fmt.Sprintf("Half Joy-Con %d", playerNum), remap)
 		case jcpc.TypeRight:
-			return output.NewUInput(output.MappingR, fmt.Sprintf("Half Joy-Con %d", playerNum))
+			return output.NewUInput(output.MappingR, fmt.Sprintf("Half Joy-Con %d", playerNum), remap)
 		case jcpc.TypeBoth:
-			return output.NewUInput(output.MappingDual, fmt.Sprintf("Full Joy-Con %d", playerNum))
+			return output.NewUInput(output.MappingDual, fmt.Sprintf("Full Joy-Con %d", playerNum), remap)
 		}
 		panic("bad joycon type")
 	}

--- a/prog4/jcpc/interface.go
+++ b/prog4/jcpc/interface.go
@@ -71,7 +71,7 @@ type Output interface {
 	Close() error
 }
 
-type OutputFactory func(t JoyConType, playerNum int) (Output, error)
+type OutputFactory func(t JoyConType, playerNum int, remap InputRemappingOptions) (Output, error)
 
 type Interface interface {
 	JoyConNotify
@@ -161,4 +161,16 @@ const (
 
 func (i InputMode) NeedsEmptyRumbles() bool {
 	return i == InputActivePolling
+}
+
+//Options specifies Options for changing the programms behavior (for example obtained via cli-flags)
+//Currently only input remapping is implemented but could be extanded to log-levels, bluetooth pairing options etc.
+type Options struct{
+	InputRemapping InputRemappingOptions
+}
+
+//InputRemappingOptions specifies if and how Buttons or Axes should be remapped
+//currently only Axis-Inversion is implemented
+type InputRemappingOptions struct {
+	InvertedAxes []AxisID
 }

--- a/prog4/jcpc/interface.go
+++ b/prog4/jcpc/interface.go
@@ -164,8 +164,7 @@ func (i InputMode) NeedsEmptyRumbles() bool {
 }
 
 //Options specifies Options for changing the programms behavior (for example obtained via cli-flags)
-//Currently only input remapping is implemented but could be extanded to log-levels, bluetooth pairing options etc.
-type Options struct{
+type Options struct {
 	InputRemapping InputRemappingOptions
 }
 

--- a/prog4/output/keymap_common.go
+++ b/prog4/output/keymap_common.go
@@ -105,10 +105,10 @@ var MappingDual = ControllerMapping{
 	},
 }
 
-func RemapInputs(mappings *ControllerMapping, mods jcpc.InputRemappingOptions){
-	for _,searched := range mods.InvertedAxes{
-		for i,axis := range mappings.Axes{
-			if axis.Axis == searched{
+func RemapInputs(mappings *ControllerMapping, mods jcpc.InputRemappingOptions) {
+	for _, searched := range mods.InvertedAxes {
+		for i, axis := range mappings.Axes {
+			if axis.Axis == searched {
 				mappings.Axes[i].Invert = !axis.Invert
 			}
 		}

--- a/prog4/output/keymap_common.go
+++ b/prog4/output/keymap_common.go
@@ -104,3 +104,13 @@ var MappingDual = ControllerMapping{
 		{jcpc.Axis_R_Vertical, false, "SecondStickVertical"},
 	},
 }
+
+func RemapInputs(mappings *ControllerMapping, mods jcpc.InputRemappingOptions){
+	for _,searched := range mods.InvertedAxes{
+		for i,axis := range mappings.Axes{
+			if axis.Axis == searched{
+				mappings.Axes[i].Invert = !axis.Invert
+			}
+		}
+	}
+}

--- a/prog4/output/uinput_linux.go
+++ b/prog4/output/uinput_linux.go
@@ -194,9 +194,9 @@ func (o *uinput) setupOldKernel(m ControllerMapping, name string) error {
 	return nil
 }
 
-func NewUInput(m ControllerMapping, name string,remaps jcpc.InputRemappingOptions) (jcpc.Output, error) {
+func NewUInput(m ControllerMapping, name string, remaps jcpc.InputRemappingOptions) (jcpc.Output, error) {
 
-	RemapInputs(&m,remaps)
+	RemapInputs(&m, remaps)
 
 	o := &uinput{}
 

--- a/prog4/output/uinput_linux.go
+++ b/prog4/output/uinput_linux.go
@@ -194,7 +194,10 @@ func (o *uinput) setupOldKernel(m ControllerMapping, name string) error {
 	return nil
 }
 
-func NewUInput(m ControllerMapping, name string) (jcpc.Output, error) {
+func NewUInput(m ControllerMapping, name string,remaps jcpc.InputRemappingOptions) (jcpc.Output, error) {
+
+	RemapInputs(&m,remaps)
+
 	o := &uinput{}
 
 	fd, err := unix.Open("/dev/uinput", unix.O_RDWR|unix.O_NONBLOCK, 0)


### PR DESCRIPTION
Fixes #18 .

You can now specify --invert (L/R)(V/H) when running jcdriver to invert a specific axis.

I had to modify a whole bunch of files to properly pass the options to the input-processing.
It basically boils down to:
- interface.go : Now containes the new Options-Struct
- main.go : Specifies and parses cli-Options into an Options-Struct
- Manager.go : New() receives an Options struct. The Input-Remapping part of the options is passed on to the output factory
- output_uinput.go : passes the remapping-options to the instantiated uinput thingy
- output_linux.go : apply the modifications to the received keymapping

This is a lot of stuff for axis inversion but it will come in handy when implementing stuff like button remapping or other options for the manager (log-levels, bluetooth-behavior etc.)