### PR TITLE
add remap arg to output_generic

### DIFF
--- a/prog4/jcdriver/output_generic.go
+++ b/prog4/jcdriver/output_generic.go
@@ -8,7 +8,7 @@ import (
 )
 
 func getOutputFactory() jcpc.OutputFactory {
-	return func(t jcpc.JoyConType, playerNum int) (jcpc.Output, error) {
+	return func(t jcpc.JoyConType, playerNum int, remap InputRemappingOptions) (jcpc.Output, error) {
 		return output.NewConsole(t, playerNum)
 	}
 }


### PR DESCRIPTION
added remap argument to output_generic return function of type jcpc.OutputFactory to match type defined in jcpc/interface.go

This fixes #36 