### PR TITLE
Help for write command

### DIFF
--- a/prog4/consoleiface/input.go
+++ b/prog4/consoleiface/input.go
@@ -395,7 +395,7 @@ func cmdSPIWrite(m *Manager, argv []string) {
 	}
 
 	if len(argv) < 3 {
-		fmt.Println("please specify the range: read [jc] [start=0x6000] [size=0x0100] [outfile=stdout]")
+		fmt.Println("please specify the range: write [jc] [start=0x6000] [size=0x02] [byte=0x00] [byte=0x00]]")
 		return
 	}
 


### PR DESCRIPTION
Write command is showing the help for `read`

Locks like it needs the address size and as much bytes as size says.

Probably the nil return should be fixed too. Not sure if SPIWrite can return success on operation.

btw: Is write command operative. Don't seems to affect in my case but this are generic joycons clones.